### PR TITLE
docs: update key mappings documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,18 @@ Plus all console buffer mappings.
 | `<C-o>` | Toggle verbose |
 | `<C-t>` | Show todo |
 | `<C-_>` | Undo |
-| `<C-z>` | Suspend |
 | `<C-v>` | Paste |
+
+### Agent-Specific (Codex)
+
+| Key | Action |
+|-----|--------|
+| `<C-t>` | Show transcript |
+| `<Home>` | Home |
+| `<End>` | End |
+| `<PageUp>` | Page up |
+| `<PageDown>` | Page down |
+| `q` | Quit |
 
 > [!IMPORTANT]
 > Some key combinations (`<C-Enter>`, `<S-Tab>`) require modern terminal emulators like Kitty, WezTerm, or Ghostty. Use alternatives like `<F5>` or `:w` if these don't work.
@@ -362,7 +372,6 @@ vim.keymap.set('n', '<C-k>', '<Plug>(aibo-prompt-submit-close)', { buffer = bufn
 | `<Plug>(aibo-claude-verbose)` | Toggle verbose |
 | `<Plug>(aibo-claude-todo)` | Show todo |
 | `<Plug>(aibo-claude-undo)` | Undo |
-| `<Plug>(aibo-claude-suspend)` | Suspend |
 | `<Plug>(aibo-claude-paste)` | Paste |
 
 #### Codex Agent

--- a/doc/aibo.txt
+++ b/doc/aibo.txt
@@ -522,7 +522,6 @@ Claude agent mappings (normal and insert mode):
 	<C-o>		Toggle verbose
 	<C-t>		Show todo
 	<C-_>		Undo (also <C-->)
-	<C-z>		Suspend
 	<C-v>		Paste
 	?		Show shortcuts
 	!		Enter bash mode
@@ -578,7 +577,6 @@ Claude agent <Plug> mappings~
 	<Plug>(aibo-claude-verbose)		Toggle verbose
 	<Plug>(aibo-claude-todo)		Show todo
 	<Plug>(aibo-claude-undo)		Undo
-	<Plug>(aibo-claude-suspend)		Suspend
 	<Plug>(aibo-claude-paste)		Paste
 	<Plug>(aibo-claude-shortcuts)		Show shortcuts
 	<Plug>(aibo-claude-bash-mode)		Enter bash mode

--- a/ftplugin/aibo-agent-claude.lua
+++ b/ftplugin/aibo-agent-claude.lua
@@ -11,7 +11,6 @@ local CLAUDE_CODES = {
   verbose = "\015",
   todo = "\020",
   undo = "\031",
-  suspend = "\026",
   paste = "\022",
 }
 


### PR DESCRIPTION
## Summary
- Remove deprecated suspend key mappings from Claude agent documentation
- Add missing Codex agent-specific key mappings section to README
- Clean up unused suspend code from ftplugin

## Details
The suspend functionality has been removed from Claude, but the documentation still referenced it. This PR updates all documentation to reflect the current state of the plugin.

### Changes made:
1. **README.md**: Removed `<C-z>` suspend mapping and added Codex agent section
2. **doc/aibo.txt**: Removed suspend references from help documentation  
3. **ftplugin/aibo-agent-claude.lua**: Removed unused suspend code

## Test plan
- [x] Verify documentation accurately reflects current keybindings
- [x] Check that all Codex mappings are documented
- [x] Ensure no references to suspend functionality remain

🤖 Generated with [Claude Code](https://claude.ai/code)