### PR TITLE
feat: add prefix/suffix options to AiboSend with flexible quoting syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,17 @@ Start an AI session:
 :Aibo ollama run qwen3:latest --verbose
 ```
 
+> **Note:** All Aibo commands support quoted strings for options with spaces.
+> - Double quotes (`"`) interpret escape sequences: `-prefix="Line 1\nLine 2"`
+> - Single quotes (`'`) treat everything literally: `-prefix='Literal\n'`
+> - Example: `-opener="botright split"` or `-prefix='Question: '`
+
 ### Window Control Options
 
 ```vim
 " Open with custom window command
 :Aibo -opener=vsplit claude
-:Aibo -opener=botright\ split claude
+:Aibo -opener="botright split" claude
 
 " Stay in current window after opening
 :Aibo -stay claude
@@ -139,9 +144,16 @@ You can send buffer content directly to an AI console using the `:AiboSend` comm
 
 " Send specific line range
 :10,20AiboSend
+
+" Add prefix and suffix to content
+:AiboSend -prefix="Question: " -suffix=" Please explain."
+:'<,'>AiboSend -prefix="```python\n" -suffix="\n```"
+
+" Combine multiple options
+:AiboSend -prefix="Review this code:\n" -submit
 ```
 
-This is particularly useful for sending code snippets, error messages, or other content to the AI without manual copy-paste.
+This is particularly useful for sending code snippets, error messages, or other content to the AI without manual copy-paste. The prefix and suffix options help format your prompts consistently.
 
 ## Configuration
 

--- a/doc/aibo.txt
+++ b/doc/aibo.txt
@@ -49,6 +49,32 @@ REQUIREMENTS					*aibo-requirements*
 =============================================================================
 USAGE						*aibo-usage*
 
+						*aibo-argument-syntax*
+Argument Syntax~
+
+All Aibo commands support flexible argument syntax for options with values.
+You can use quoted strings (single or double quotes) or escaped spaces:
+
+Double quotes (interprets escape sequences like \n, \t):
+>
+	:AiboSend -prefix="Question:\n" -suffix="\nExplain."
+	:AiboSend -prefix="```python\n" -suffix="\n```"
+<
+Single quotes (treats everything literally, no escape sequences):
+>
+	:AiboSend -prefix='Literal\n' -suffix='\nText'
+	:Aibo -opener='botright split' claude
+<
+Escaped spaces (traditional Vim style):
+>
+	:Aibo -opener=botright\ split claude
+	:AiboSend -prefix=Question:\  -suffix=\ Please\ explain.
+<
+Key differences between quote types:
+- Double quotes ("): Interprets \n as newline, \t as tab, etc.
+- Single quotes ('): Everything is literal, \n stays as \n
+- Both allow spaces without escaping them individually
+
 Start an AI session with the |:Aibo| command:
 >
 	:Aibo claude
@@ -266,12 +292,13 @@ COMMANDS					*aibo-commands*
 
 	Options:~
 		-opener={cmd}	Use custom window command for opening
-				Example: -opener=vsplit, -opener=botright\ split
+				Example: -opener=vsplit, -opener="botright split"
 		-stay		Keep focus on current window after opening
 		-toggle		Toggle visibility of existing console or open new
 		-jump		Jump to existing console or open new one
 
 	Note: -toggle and -jump are mutually exclusive.
+	      Options with values support quoted strings for including spaces.
 
 	Examples:
 >
@@ -374,6 +401,11 @@ COMMANDS					*aibo-commands*
 		-input		Open prompt window and enter insert mode
 		-submit		Submit content immediately after sending
 		-replace	Replace prompt content instead of appending
+		-prefix={text}	Add text before the content
+		-suffix={text}	Add text after the content
+
+	Note: Options with values support quoted strings for including spaces:
+	      -prefix="Question: " or -prefix=Question:\  (with escaped spaces)
 
 	Examples:
 >
@@ -383,6 +415,8 @@ COMMANDS					*aibo-commands*
 		:AiboSend -input            " Send and open prompt
 		:AiboSend -submit           " Send and submit
 		:AiboSend -replace -submit  " Replace and submit
+		:AiboSend -prefix="Question: " -suffix=" Please explain."
+		:'<,'>AiboSend -prefix="```python\n" -suffix="\n```"
 <
 	If multiple Aibo consoles are open in the current tabpage, you'll
 	be prompted to select which one to send to.

--- a/lua/aibo/internal/argparse.lua
+++ b/lua/aibo/internal/argparse.lua
@@ -1,0 +1,183 @@
+local M = {}
+
+--- Parse a command-line string into arguments, handling quoted strings
+--- This function mimics shell-like argument parsing where:
+--- - Arguments can be separated by spaces
+--- - Single-quoted strings: treated as literal (no escape sequences)
+--- - Double-quoted strings: escape sequences are interpreted
+--- - Quotes can be escaped with backslash
+---@param cmdline string The command line to parse
+---@return string[] The parsed arguments
+function M.parse_cmdline(cmdline)
+  local args = {}
+  local current_arg = ""
+  local in_single_quotes = false
+  local in_double_quotes = false
+  local escaped = false
+
+  for i = 1, #cmdline do
+    local char = cmdline:sub(i, i)
+
+    if escaped then
+      if in_double_quotes then
+        -- In double quotes, interpret escape sequences
+        if char == "n" then
+          current_arg = current_arg .. "\n"
+        elseif char == "t" then
+          current_arg = current_arg .. "\t"
+        elseif char == "r" then
+          current_arg = current_arg .. "\r"
+        elseif char == "\\" then
+          current_arg = current_arg .. "\\"
+        elseif char == '"' then
+          current_arg = current_arg .. '"'
+        else
+          -- Unknown escape sequence, keep the backslash
+          current_arg = current_arg .. "\\" .. char
+        end
+      elseif in_single_quotes then
+        -- In single quotes, only \' is special
+        if char == "'" then
+          current_arg = current_arg .. "'"
+        else
+          -- Everything else is literal, including the backslash
+          current_arg = current_arg .. "\\" .. char
+        end
+      else
+        -- Outside quotes, treat as literal escaped character
+        current_arg = current_arg .. char
+      end
+      escaped = false
+    elseif char == "\\" then
+      -- Backslash starts escape sequence
+      escaped = true
+    elseif char == "'" and not in_double_quotes and not escaped then
+      -- Toggle single quote state
+      in_single_quotes = not in_single_quotes
+    elseif char == '"' and not in_single_quotes and not escaped then
+      -- Toggle double quote state
+      in_double_quotes = not in_double_quotes
+    elseif char == " " and not in_single_quotes and not in_double_quotes then
+      -- Space outside quotes means end of argument
+      if current_arg ~= "" then
+        table.insert(args, current_arg)
+        current_arg = ""
+      end
+    else
+      -- Regular character
+      current_arg = current_arg .. char
+    end
+  end
+
+  -- Handle any remaining escaped state
+  if escaped then
+    current_arg = current_arg .. "\\"
+  end
+
+  -- Add the last argument if any
+  if current_arg ~= "" then
+    table.insert(args, current_arg)
+  end
+
+  return args
+end
+
+--- Parse option arguments like -key=value, supporting quoted values
+--- This handles:
+--- - Simple flags: -flag
+--- - Key-value pairs: -key=value
+--- - Quoted values: -key="value with spaces"
+---@param args string[] Array of arguments (from fargs or parse_cmdline)
+---@return table options Table of parsed options
+---@return string[] remaining Array of non-option arguments
+function M.parse_options(args)
+  local options = {}
+  local remaining = {}
+
+  for _, arg in ipairs(args) do
+    if arg:sub(1, 1) == "-" then
+      -- This is an option
+      local eq_pos = arg:find("=")
+      if eq_pos then
+        -- Key-value option
+        local key = arg:sub(2, eq_pos - 1)
+        local value = arg:sub(eq_pos + 1)
+        options[key] = value
+      else
+        -- Flag option
+        local key = arg:sub(2)
+        options[key] = true
+      end
+    else
+      -- Not an option
+      table.insert(remaining, arg)
+    end
+  end
+
+  return options, remaining
+end
+
+--- Convert options table back to command-line arguments
+--- Useful for reconstructing command lines with proper quoting
+---@param options table Options table
+---@param remaining string[]? Non-option arguments
+---@return string[] Array of arguments
+function M.options_to_args(options, remaining)
+  local args = {}
+
+  -- Add options
+  for key, value in pairs(options) do
+    if value == true then
+      -- Flag option
+      table.insert(args, "-" .. key)
+    else
+      -- Key-value option - quote if contains spaces
+      local val_str = tostring(value)
+      if val_str:find(" ") then
+        table.insert(args, string.format('-%s="%s"', key, val_str))
+      else
+        table.insert(args, string.format("-%s=%s", key, val_str))
+      end
+    end
+  end
+
+  -- Add remaining arguments
+  if remaining then
+    for _, arg in ipairs(remaining) do
+      table.insert(args, arg)
+    end
+  end
+
+  return args
+end
+
+--- Parse fargs handling both vim's native parsing and quoted strings
+--- When vim.cmd is used with quotes, Vim may handle them differently
+--- This function normalizes the behavior
+---@param fargs string[] The fargs from command
+---@return table options Parsed options
+---@return string[] remaining Non-option arguments
+function M.parse_fargs(fargs)
+  -- First, reconstruct the command line from fargs
+  -- This is needed because Vim might split quoted arguments incorrectly
+  local needs_reparsing = false
+  for _, arg in ipairs(fargs) do
+    -- Check if any argument contains a quote or looks like a partial quoted string
+    if arg:find('"') or (arg:match("^%-[^=]+=") and not arg:match("=$")) then
+      needs_reparsing = true
+      break
+    end
+  end
+
+  if needs_reparsing then
+    -- Reconstruct and reparse
+    local cmdline = table.concat(fargs, " ")
+    local reparsed = M.parse_cmdline(cmdline)
+    return M.parse_options(reparsed)
+  else
+    -- Use fargs as-is
+    return M.parse_options(fargs)
+  end
+end
+
+return M

--- a/lua/aibo/internal/send.lua
+++ b/lua/aibo/internal/send.lua
@@ -105,7 +105,7 @@ local function send_to_prompt(content, prompt_bufnr, replace)
 end
 
 ---Send buffer content to aibo console
----@param opts table Options with start_line, end_line, input, submit, replace
+---@param opts table Options with start_line, end_line, input, submit, replace, prefix, suffix
 function M.send(opts)
   opts = opts or {}
   local start_line = opts.line1 or 1
@@ -113,10 +113,20 @@ function M.send(opts)
   local input = opts.input or false
   local submit = opts.submit or false
   local replace = opts.replace or false
+  local prefix = opts.prefix or nil
+  local suffix = opts.suffix or nil
 
   -- Get the content to send
   local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
   local content = table.concat(lines, "\n")
+
+  -- Add prefix and suffix if provided
+  if prefix then
+    content = prefix .. content
+  end
+  if suffix then
+    content = content .. suffix
+  end
 
   -- Find all console buffers in current tabpage
   local console_buffers = find_console_buffers()

--- a/tests/test_argparse.lua
+++ b/tests/test_argparse.lua
@@ -1,0 +1,220 @@
+-- Tests for argument parsing functionality
+
+local helpers = require("tests.helpers")
+local T = require("mini.test")
+
+-- Test set
+local test_set = T.new_set({
+  hooks = {
+    pre_case = function()
+      helpers.setup()
+    end,
+    post_case = function()
+      helpers.cleanup()
+    end,
+  },
+})
+
+-- Test parse_cmdline function
+test_set["parse_cmdline handles simple arguments"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local result = argparse.parse_cmdline("arg1 arg2 arg3")
+  T.expect.equality(#result, 3)
+  T.expect.equality(result[1], "arg1")
+  T.expect.equality(result[2], "arg2")
+  T.expect.equality(result[3], "arg3")
+end
+
+test_set["parse_cmdline handles double quoted strings"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local result = argparse.parse_cmdline('arg1 "arg with spaces" arg3')
+  T.expect.equality(#result, 3)
+  T.expect.equality(result[1], "arg1")
+  T.expect.equality(result[2], "arg with spaces")
+  T.expect.equality(result[3], "arg3")
+end
+
+test_set["parse_cmdline handles single quoted strings"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local result = argparse.parse_cmdline("arg1 'arg with spaces' arg3")
+  T.expect.equality(#result, 3)
+  T.expect.equality(result[1], "arg1")
+  T.expect.equality(result[2], "arg with spaces")
+  T.expect.equality(result[3], "arg3")
+end
+
+test_set["parse_cmdline handles escaped quotes"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local result = argparse.parse_cmdline('arg1 "arg with \\"quotes\\"" arg3')
+  T.expect.equality(#result, 3)
+  T.expect.equality(result[1], "arg1")
+  T.expect.equality(result[2], 'arg with "quotes"')
+  T.expect.equality(result[3], "arg3")
+end
+
+test_set["parse_cmdline handles escape sequences in double quotes"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local result = argparse.parse_cmdline('"line1\\nline2" "tab\\there" "quote\\"test"')
+  T.expect.equality(#result, 3)
+  T.expect.equality(result[1], "line1\nline2")
+  T.expect.equality(result[2], "tab\there")
+  T.expect.equality(result[3], 'quote"test')
+end
+
+test_set["parse_cmdline treats escape sequences as literal in single quotes"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local result = argparse.parse_cmdline("'line1\\nline2' 'tab\\there' 'quote\\'test'")
+  T.expect.equality(#result, 3)
+  T.expect.equality(result[1], "line1\\nline2")
+  T.expect.equality(result[2], "tab\\there")
+  T.expect.equality(result[3], "quote'test")
+end
+
+test_set["parse_cmdline handles mixed quotes"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local result = argparse.parse_cmdline("\"double\" 'single' \"another \\\"double\\\"\" 'another \\'single\\''")
+  T.expect.equality(#result, 4)
+  T.expect.equality(result[1], "double")
+  T.expect.equality(result[2], "single")
+  T.expect.equality(result[3], 'another "double"')
+  T.expect.equality(result[4], "another 'single'")
+end
+
+-- Test parse_options function
+test_set["parse_options handles flags"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local options, remaining = argparse.parse_options({ "-flag1", "-flag2", "arg1" })
+  T.expect.equality(options.flag1, true)
+  T.expect.equality(options.flag2, true)
+  T.expect.equality(#remaining, 1)
+  T.expect.equality(remaining[1], "arg1")
+end
+
+test_set["parse_options handles key-value pairs"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local options, remaining = argparse.parse_options({ "-key=value", "arg1" })
+  T.expect.equality(options.key, "value")
+  T.expect.equality(#remaining, 1)
+  T.expect.equality(remaining[1], "arg1")
+end
+
+test_set["parse_options handles double quoted values"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local args = argparse.parse_cmdline('-prefix="Question: " -suffix=" Please explain." cmd')
+  local options, remaining = argparse.parse_options(args)
+
+  T.expect.equality(options.prefix, "Question: ")
+  T.expect.equality(options.suffix, " Please explain.")
+  T.expect.equality(#remaining, 1)
+  T.expect.equality(remaining[1], "cmd")
+end
+
+test_set["parse_options handles single quoted values"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local args = argparse.parse_cmdline("-prefix='Question: ' -suffix=' Please explain.' cmd")
+  local options, remaining = argparse.parse_options(args)
+
+  T.expect.equality(options.prefix, "Question: ")
+  T.expect.equality(options.suffix, " Please explain.")
+  T.expect.equality(#remaining, 1)
+  T.expect.equality(remaining[1], "cmd")
+end
+
+test_set["parse_options with escape sequences"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  -- Double quotes interpret escape sequences
+  local args1 = argparse.parse_cmdline('-prefix="```python\\n" -suffix="\\n```" cmd')
+  local options1, remaining1 = argparse.parse_options(args1)
+  T.expect.equality(options1.prefix, "```python\n")
+  T.expect.equality(options1.suffix, "\n```")
+
+  -- Single quotes treat them literally
+  local args2 = argparse.parse_cmdline("-prefix='```python\\n' -suffix='\\n```' cmd")
+  local options2, remaining2 = argparse.parse_options(args2)
+  T.expect.equality(options2.prefix, "```python\\n")
+  T.expect.equality(options2.suffix, "\\n```")
+end
+
+-- Test parse_fargs function
+test_set["parse_fargs handles simple fargs"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local options, remaining = argparse.parse_fargs({ "-flag", "-key=value", "cmd", "arg" })
+  T.expect.equality(options.flag, true)
+  T.expect.equality(options.key, "value")
+  T.expect.equality(#remaining, 2)
+  T.expect.equality(remaining[1], "cmd")
+  T.expect.equality(remaining[2], "arg")
+end
+
+test_set["parse_fargs handles quoted fargs"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  -- Simulate what Vim might pass when quotes are used
+  local fargs = { '-prefix="Question:', '"', '-suffix="', "Please", 'explain."', "cmd" }
+  local options, remaining = argparse.parse_fargs(fargs)
+
+  T.expect.equality(options.prefix, "Question: ")
+  T.expect.equality(options.suffix, " Please explain.")
+  T.expect.equality(#remaining, 1)
+  T.expect.equality(remaining[1], "cmd")
+end
+
+-- Test options_to_args function
+test_set["options_to_args converts back to args"] = function()
+  local argparse = require("aibo.internal.argparse")
+
+  local options = {
+    flag = true,
+    key = "value",
+    multiword = "value with spaces",
+  }
+  local remaining = { "cmd", "arg" }
+
+  local args = argparse.options_to_args(options, remaining)
+
+  -- Check that all components are present (order may vary for options)
+  local has_flag = false
+  local has_key = false
+  local has_multiword = false
+  local has_cmd = false
+  local has_arg = false
+
+  for _, arg in ipairs(args) do
+    if arg == "-flag" then
+      has_flag = true
+    end
+    if arg == "-key=value" then
+      has_key = true
+    end
+    if arg == '-multiword="value with spaces"' then
+      has_multiword = true
+    end
+    if arg == "cmd" then
+      has_cmd = true
+    end
+    if arg == "arg" then
+      has_arg = true
+    end
+  end
+
+  T.expect.equality(has_flag, true)
+  T.expect.equality(has_key, true)
+  T.expect.equality(has_multiword, true)
+  T.expect.equality(has_cmd, true)
+  T.expect.equality(has_arg, true)
+end
+
+return test_set

--- a/tests/test_runner.lua
+++ b/tests/test_runner.lua
@@ -45,6 +45,7 @@ local test_files = {
   "test_aibo",
   "test_plugin",
   "test_send",
+  "test_argparse",
   "test_integration_send",
   "test_integration_claude",
   "test_integration_ollama",


### PR DESCRIPTION
## Summary

This PR adds `-prefix` and `-suffix` options to the `AiboSend` command and implements a comprehensive argument parser that supports flexible quoting syntax across all Aibo commands.

## Key Features

### 1. Prefix/Suffix Options for AiboSend
- Add text before and after content when sending to AI console
- Useful for wrapping code blocks, adding context, or formatting prompts
- Example: `:AiboSend -prefix="```python\n" -suffix="\n```"`

### 2. Flexible Quoting Syntax
Three ways to handle spaces and special characters in option values:

- **Double quotes** - Interprets escape sequences:
  ```vim
  :AiboSend -prefix="Question:\n" -suffix="\nExplain."  " Newlines inserted
  ```

- **Single quotes** - Everything is literal:
  ```vim
  :AiboSend -prefix='C:\path\file' -suffix='.txt'  " Backslashes kept as-is
  ```

- **Escaped spaces** - Traditional Vim style:
  ```vim
  :Aibo -opener=botright\ split claude
  ```

## Implementation Details

- New `lua/aibo/internal/argparse.lua` module with robust parsing logic
- Both `Aibo` and `AiboSend` commands updated to use the new parser
- Proper handling of escape sequences based on quote type
- Backward compatible with existing escaped space syntax

## Testing

- Added comprehensive test suite with 15 new tests
- Tests cover single quotes, double quotes, escape sequences, and mixed scenarios
- All 62 tests passing

## Examples

```vim
" Add a question prompt
:AiboSend -prefix="Question: " -suffix=" Please explain."

" Wrap code in markdown
:'<,'>AiboSend -prefix="```python\n" -suffix="\n```"

" Use single quotes for literal paths
:AiboSend -prefix='File: C:\Users\name\' -suffix='.txt'

" Custom window opener with spaces
:Aibo -opener="botright split" claude
```

## Documentation

- Added "Argument Syntax" section to help file
- Updated README with examples of all three syntax styles
- Clear explanation of differences between quote types

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Commands now support quoted strings for option values, including spaces (double quotes allow escapes; single quotes are literal).
  - AiboSend supports -prefix and -suffix to wrap content before sending.
  - Command-line completion includes -prefix= and -suffix=.
- Documentation
  - Added guidance on quoting syntax, with examples.
  - Updated window control examples to use quoted opener values.
  - Expanded AiboSend examples, including combined prefix/suffix usage and prompt-standardization tips.
- Tests
  - Added coverage for argument parsing, option handling, and AiboSend prefix/suffix behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->