### PR TITLE
docs: add dynamic window sizing documentation using Vim script expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ To close the session, use `:bdelete!` or `:bwipeout!` on the console buffer.
 :Aibo -reuse claude
 ```
 
+> [!TIP]
+> You can use `<C-r>=` to dynamically calculate window sizes based on your terminal dimensions. This allows you to create proportional splits instead of fixed sizes:
+> ```vim
+> " Create a vertical split with 2/3 of the window width
+> :Aibo -opener="<C-r>=&columns * 2 / 3<CR>vsplit" claude
+>
+> " Create a horizontal split with 1/2 of the window height
+> :Aibo -opener="<C-r>=&lines / 2<CR>split" codex
+>
+> " Create a bottom split with 1/3 of the window height
+> :Aibo -opener="botright <C-r>=&lines / 3<CR>split" ollama run llama3
+> ```
+
 ### Intelligent Command Completion
 
 The plugin provides comprehensive tab completion for all supported interactive CLI tools:

--- a/doc/aibo.txt
+++ b/doc/aibo.txt
@@ -305,6 +305,13 @@ COMMANDS					*aibo-commands*
 				- topleft\ split, botright\ vsplit
 				- leftabove\ split, rightbelow\ vsplit
 
+				Tip: You can use Vim script expressions
+				with <C-r>= to calculate window sizes
+				dynamically based on terminal dimensions.
+				For example, to create a vertical split
+				with 2/3 of the window width:
+				:Aibo -opener="<C-r>=&columns * 2 / 3<CR>vsplit" claude
+
 	-stay			Stay in the current window after opening
 				the AI console. Useful when you want to
 				continue editing while the AI loads.
@@ -345,6 +352,11 @@ COMMANDS					*aibo-commands*
 		:Aibo -stay psql mydatabase
 		:Aibo -toggle claude
 		:Aibo -reuse node --interactive
+
+		" Dynamic window sizing with Vim script expressions
+		:Aibo -opener="<C-r>=&columns * 2 / 3<CR>vsplit" claude
+		:Aibo -opener="<C-r>=&lines / 2<CR>split" codex
+		:Aibo -opener="botright <C-r>=&lines / 3<CR>split" ollama run llama3
 <
 						*aibo-completion*
 	Intelligent Command Completion~


### PR DESCRIPTION
## Summary

This PR adds documentation for using dynamic window sizing with the `-opener` option through Vim script expressions.

## Changes

- Added a GitHub Alert (`[!TIP]`) in README.md explaining how to use `<C-r>=` for dynamic window calculations
- Updated doc/aibo.txt with the same feature explanation and examples
- Provided clear examples showing proportional splits (2/3 width, 1/2 height, 1/3 height)

## Benefits

Users can now create responsive window layouts that adapt to their terminal dimensions instead of using fixed sizes. This makes the plugin more flexible for different screen configurations.

## Examples

```vim
" Create a vertical split with 2/3 of the window width
:Aibo -opener="<C-r>=&columns * 2 / 3<CR>vsplit" claude

" Create a horizontal split with 1/2 of the window height  
:Aibo -opener="<C-r>=&lines / 2<CR>split" codex

" Create a bottom split with 1/3 of the window height
:Aibo -opener="botright <C-r>=&lines / 3<CR>split" ollama run llama3
```

This feature leverages Vim's built-in `&columns` and `&lines` variables combined with the `<C-r>=` register insertion command to calculate sizes at runtime.