### PR TITLE
docs: Fix CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Neovim](https://img.shields.io/badge/Neovim-0.10.0+-blueviolet.svg?style=flat-square&logo=Neovim&logoColor=white)](https://neovim.io/)
 [![Lua](https://img.shields.io/badge/Lua-5.1+-blue.svg?style=flat-square&logo=lua)](https://www.lua.org/)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
-[![Lua CI](https://github.com/lambdalisue/vim-aibo/actions/workflows/lua.yml/badge.svg)](https://github.com/lambdalisue/vim-aibo/actions/workflows/lua.yml)
+[![Check](https://github.com/lambdalisue/vim-aibo/actions/workflows/check.yml/badge.svg)](https://github.com/lambdalisue/vim-aibo/actions/workflows/check.yml)
 [![Test](https://github.com/lambdalisue/vim-aibo/actions/workflows/test.yml/badge.svg)](https://github.com/lambdalisue/vim-aibo/actions/workflows/test.yml)
 
 AI Bot Integration and Orchestration for Neovim


### PR DESCRIPTION
## 🎯 Purpose

Fix incorrect CI badge link in README.md that was pointing to the old workflow file.

## 📝 Description  

### What Changed
- Updated CI badge link from `lua.yml` to `check.yml` to reflect the actual workflow file name

### Implementation Approach
Simple documentation fix - correcting the badge URL to match the renamed workflow file.

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [x] 📝 Documentation (documentation changes only)
- [ ] 🚀 Performance (performance improvements)
- [ ] ✅ Test (test additions or corrections)

## ✅ Checklist

### Code Quality
- [x] My changes generate no new warnings
- N/A - Documentation only change

### Documentation
- [x] I have updated relevant documentation
- The change itself is a documentation fix

### Testing
- N/A - Documentation only change

## 🔗 Related Issues

This fixes the CI badge that was showing incorrect status after the workflow was renamed.