### PR TITLE
fix: Fix issue where empty Enter key sends "0" to terminal

### DIFF
--- a/lua/aibo/integration/claude.lua
+++ b/lua/aibo/integration/claude.lua
@@ -278,7 +278,7 @@ function M.setup_mappings(bufnr)
   end
 
   local send = function(key)
-    local code = aibo.resolve(key)
+    local code = aibo.resolve(key) or key
     aibo.send(code, bufnr)
   end
 

--- a/lua/aibo/integration/codex.lua
+++ b/lua/aibo/integration/codex.lua
@@ -261,7 +261,7 @@ function M.setup_mappings(bufnr)
   end
 
   local send = function(key)
-    local code = aibo.resolve(key)
+    local code = aibo.resolve(key) or key
     aibo.send(code, bufnr)
   end
 

--- a/lua/aibo/internal/console_window.lua
+++ b/lua/aibo/internal/console_window.lua
@@ -531,7 +531,7 @@ function M.send(bufnr, input)
   -- chansend returns the number of bytes sent, or 0 on failure
   if vim.fn.chansend(job_id, input) == 0 then
     vim.notify(
-      "Failed to send input to terminal job: " .. tostring(job_id),
+      string.format("Failed to send input to terminal job %d (Keycode: %s)", job_id, vim.fn.char2nr(input)),
       vim.log.levels.ERROR,
       { title = "Aibo console Error" }
     )

--- a/lua/aibo/internal/console_window.lua
+++ b/lua/aibo/internal/console_window.lua
@@ -78,7 +78,7 @@ local function setup_mappings(bufnr)
     local winid = vim.api.nvim_get_current_win()
     local info = M.get_info_by_winid(winid)
     if info and info.bufnr then
-      local code = aibo.resolve(key)
+      local code = aibo.resolve(key) or key
       M.send(info.bufnr, code)
     end
   end
@@ -87,7 +87,7 @@ local function setup_mappings(bufnr)
     local winid = vim.api.nvim_get_current_win()
     local info = M.get_info_by_winid(winid)
     if info and info.bufnr then
-      local code = aibo.resolve(key)
+      local code = aibo.resolve(key) or key
       M.submit(info.bufnr, code)
     end
   end

--- a/lua/aibo/internal/console_window.lua
+++ b/lua/aibo/internal/console_window.lua
@@ -512,6 +512,10 @@ end
 ---   local termcode = require("aibo").termcode
 ---   console.send(bufnr, termcode.resolve("<C-c>"))  -- Send Ctrl-C
 function M.send(bufnr, input)
+  -- Do nothing for empty input
+  if not input or input == "" then
+    return true
+  end
   if not M.get_info_by_bufnr(bufnr) then
     vim.notify("Invalid buffer: " .. tostring(bufnr), vim.log.levels.ERROR, { title = "Aibo console Error" })
     return
@@ -526,8 +530,6 @@ function M.send(bufnr, input)
     )
     return nil
   end
-  -- Ensure input is a string (handle nil or v:null)
-  input = input or ""
   -- chansend returns the number of bytes sent, or 0 on failure
   if vim.fn.chansend(job_id, input) == 0 then
     vim.notify(
@@ -564,9 +566,6 @@ function M.submit(bufnr, input)
   local config = aibo.get_config()
   local submit_key = termcode.resolve(config.submit_key) or "\r"
   local submit_delay = config.submit_delay
-
-  -- Ensure input is a string (handle nil or v:null)
-  input = input or ""
 
   -- First send input text
   if not M.send(bufnr, input) then

--- a/lua/aibo/internal/prompt_window.lua
+++ b/lua/aibo/internal/prompt_window.lua
@@ -101,7 +101,7 @@ local function setup_mappings(bufnr)
     local winid = vim.api.nvim_get_current_win()
     local info = M.get_info_by_winid(winid)
     if info and info.console_info then
-      local code = aibo.resolve(key)
+      local code = aibo.resolve(key) or key
       console.send(info.console_info.bufnr, code)
     end
   end


### PR DESCRIPTION
## 🎯 Purpose

Fixed an issue where pressing the Enter key with empty input in console or prompt windows would send an unintended "0" character.

## 📝 Description

### Root Cause
- When `M.send()` function sent an empty string to `chansend`, it returned 0 (indicating 0 bytes sent successfully)
- This was incorrectly interpreted as an error, and `char2nr("")` in the error message displayed 0

### Fix
- Modified `M.send()` function to skip processing and return normally for empty strings
- Empty input is now treated as a valid operation, skipping unnecessary processing

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)

## 🧪 Testing

### Manual Testing Steps
1. Open console with `:Aibo claude`
2. Press Enter key without any input in the prompt
3. Verify that "0" is not sent

### Behavior Before Fix
- Empty Enter sends "0"
- May display error message "Failed to send input to terminal job (Keycode: 0)"

### Behavior After Fix
- Empty Enter is processed normally (nothing is sent)
- No unnecessary error messages are displayed

## ✅ Checklist

### Code Quality
- [x] Code follows the project's style guidelines
- [x] Self-review has been performed
- [x] No new warnings are generated

### Testing
- [x] Functionality confirmed through manual testing
- [x] Verified no impact on existing features

## 🔗 Related Issues

This issue was discovered through user reports.

## 📊 Performance Impact

No negative performance impact. In fact, slight improvement by skipping unnecessary processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More robust key handling ensures inputs are sent even when a mapping isn't found.
- Bug Fixes
  - Prevented failures when a key can't be resolved by falling back to the original input.
  - Ignored empty or nil submissions to avoid unintended actions.
- Improvements
  - Enhanced error messages with clearer context for easier troubleshooting.
  - Consistent behavior across integrations and windows for sending inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->