### PR TITLE
fix: Fix <C-Enter> and <F5> mappings in insert mode of prompt buffer

### DIFF
--- a/ftplugin/aibo-prompt.lua
+++ b/ftplugin/aibo-prompt.lua
@@ -18,8 +18,10 @@ if not (cfg and cfg.no_default_mappings) then
   local opts = { buffer = bufnr, nowait = true, silent = true }
   vim.keymap.set({ "n", "i" }, "<C-g><C-o>", "<Plug>(aibo-send)", { buffer = bufnr, nowait = true })
   vim.keymap.set("n", "<CR>", "<Plug>(aibo-submit)", opts)
-  vim.keymap.set({ "n", "i" }, "<C-Enter>", "<Plug>(aibo-submit)<Cmd>q<CR>", opts)
-  vim.keymap.set({ "n", "i" }, "<F5>", "<Plug>(aibo-submit)<Cmd>q<CR>", opts)
+  vim.keymap.set("n", "<C-Enter>", "<Plug>(aibo-submit)<Cmd>q<CR>", opts)
+  vim.keymap.set("n", "<F5>", "<Plug>(aibo-submit)<Cmd>q<CR>", opts)
+  vim.keymap.set("i", "<C-Enter>", "<Esc><Plug>(aibo-submit)<Cmd>q<CR>", opts)
+  vim.keymap.set("i", "<F5>", "<Esc><Plug>(aibo-submit)<Cmd>q<CR>", opts)
   vim.keymap.set({ "n", "i" }, "<C-c>", "<Plug>(aibo-send)<Esc>", opts)
   vim.keymap.set({ "n", "i" }, "g<C-c>", "<Plug>(aibo-send)<C-c>", opts)
   vim.keymap.set({ "n", "i" }, "<C-l>", "<Plug>(aibo-send)<C-l>", opts)


### PR DESCRIPTION
## 🎯 Purpose

Fixes a bug where `<C-Enter>` and `<F5>` key mappings were not working correctly in insert mode within the prompt buffer.

## 📝 Description

### What Changed
- Split `<C-Enter>` and `<F5>` keymaps into separate normal and insert mode mappings
- Added `<Esc>` prefix for insert mode mappings to properly exit insert mode before executing the plug mapping
- Ensures consistent behavior across both normal and insert modes

### Implementation Approach
The previous implementation used `vim.keymap.set({ "n", "i" }, ...)` which tried to apply the same mapping to both modes. However, in Neovim, `<Plug>` mappings require being in normal mode to execute properly. In insert mode, the mapping needs to first escape to normal mode with `<Esc>` before executing the plug mapping.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 🔧 Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 📝 Documentation (documentation changes only)
- [ ] 🚀 Performance (performance improvements)
- [ ] ✅ Test (test additions or corrections)

## 🧪 Testing

### Manual Testing Steps
1. Open nvim-aibo prompt buffer
2. Enter insert mode with `i`
3. Press `<C-Enter>` - should submit and close the prompt
4. Open prompt again in insert mode
5. Press `<F5>` - should submit and close the prompt
6. Verify both mappings also work in normal mode

### Code Quality Checks
```
✓ luacheck: 0 warnings / 0 errors
✓ stylua: formatting passes
```

## ✅ Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] Code passes luacheck without warnings
- [x] Code is properly formatted with stylua

### Testing
- [x] Manually tested in both normal and insert modes
- [x] Verified no regression in existing key mappings

## 📊 Impact

**Changed Files:** 1 file  
**Lines Changed:** +4 -2

**Related Context:**
- Follows the pattern established in PR #30 for unified `<Plug>(aibo-send)` mappings
- Complements recent keymap improvements in `ftplugin/aibo-prompt.lua`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key mappings for Ctrl+Enter and F5 to behave consistently across modes.
  * In insert mode, these shortcuts now exit insert mode before submitting, reducing unintended input and ensuring reliable execution.
  * Normal-mode behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->