### PR TITLE
fix: use vim.opt_local instead of vim.wo for window options

### DIFF
--- a/ftplugin/aibo-console.lua
+++ b/ftplugin/aibo-console.lua
@@ -6,10 +6,10 @@ vim.b.loaded_aibo_console_ftplugin = true
 local bufnr = vim.api.nvim_get_current_buf()
 local aibo = require("aibo")
 
--- Window settings (these apply to the current window)
-vim.wo.number = false
-vim.wo.relativenumber = false
-vim.wo.signcolumn = "no"
+-- Window settings (buffer-local, apply to all windows showing this buffer)
+vim.opt_local.number = false
+vim.opt_local.relativenumber = false
+vim.opt_local.signcolumn = "no"
 
 -- Avoid "Cannot make changes, 'modifiable' is off" errors on o/O
 vim.keymap.set("n", "o", "i", { buffer = bufnr, desc = "Enter insert mode" })

--- a/ftplugin/aibo-prompt.lua
+++ b/ftplugin/aibo-prompt.lua
@@ -6,11 +6,11 @@ vim.b.loaded_aibo_prompt_ftplugin = true
 local bufnr = vim.api.nvim_get_current_buf()
 local aibo = require("aibo")
 
--- Window settings (these apply to the current window)
-vim.wo.number = false
-vim.wo.relativenumber = false
-vim.wo.signcolumn = "no"
-vim.wo.winfixheight = true
+-- Window settings (buffer-local, apply to all windows showing this buffer)
+vim.opt_local.number = false
+vim.opt_local.relativenumber = false
+vim.opt_local.signcolumn = "no"
+vim.opt_local.winfixheight = true
 
 -- Default key mappings (unless disabled in config)
 local cfg = aibo.get_buffer_config("prompt")


### PR DESCRIPTION
## 🎯 Purpose

Fixes an issue where Aibo window settings (signcolumn, number, relativenumber) were affecting global window configuration instead of being isolated to Aibo buffers.

## 📝 Description

### What Changed
- Changed `vim.wo` to `vim.opt_local` in `ftplugin/aibo-console.lua`
- Changed `vim.wo` to `vim.opt_local` in `ftplugin/aibo-prompt.lua`
- Updated comments to reflect buffer-local behavior

### Implementation Approach

Previously, the ftplugin files used `vim.wo` (window-local options) which only affects the current window. This meant:
- Settings could leak to other buffers when switching windows
- The same Aibo buffer in different windows might have inconsistent settings

By using `vim.opt_local` instead, the settings become buffer-local and automatically apply to **all windows** displaying the Aibo buffer, without affecting other buffers.

## 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)

## 🧪 Testing

### Test Results
```
Total number of cases: 161
Total number of groups: 13

All tests passing ✓
```

### Manual Testing Steps
1. Open Aibo console
2. Verify `signcolumn`, `number`, and `relativenumber` are disabled in Aibo windows
3. Switch to a different buffer
4. Verify user's original settings are preserved (not affected by Aibo)

## ✅ Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### Testing
- [x] New and existing unit tests pass locally
- [x] Test coverage has not decreased

---

**Technical Note:**
The difference between `vim.wo` and `vim.opt_local` for window-local options:
- `vim.wo`: Sets option for current window only
- `vim.opt_local`: Sets option as buffer-local (applies to all windows showing the buffer)

This makes `vim.opt_local` the correct choice for ftplugin files where we want consistent behavior across all windows displaying the buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Line numbers, relative line numbers, and sign column settings now apply consistently across all windows viewing Aibo Console and Aibo Prompt buffers.
  * Fixed window height behavior now persists across splits for Aibo Prompt buffers, preventing unintended resizing.
  * UI preferences for these buffers are retained across multiple views, reducing inconsistency when opening additional splits.
  * Existing insert-mode behavior and key mappings remain unchanged, ensuring a seamless experience while benefiting from the consistent UI settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->