### PR TITLE
feat: Add <C-u> and <C-v> mappings to tool-specific ftplugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,25 +398,27 @@ Plus all console buffer mappings (with `<Plug>(aibo-send)<Key>` pattern).
 
 All Claude-specific keys use the `<Plug>(aibo-send)` pattern to send keys directly to the Claude CLI:
 
-| Key                  | Action         |
-| -------------------- | -------------- |
-| `<Tab>`              | Toggle think   |
-| `<S-Tab>`\* / `<F2>` | Switch mode    |
-| `<C-o>`              | Toggle verbose |
-| `<C-t>`              | Show todo      |
-| `<C-_>` / `<C-->`    | Undo           |
-| `<C-v>`              | Paste          |
+| Key                  | Action                    |
+| -------------------- | ------------------------- |
+| `<Tab>`              | Toggle think              |
+| `<S-Tab>`\* / `<F2>` | Switch mode               |
+| `<C-o>`              | Toggle verbose            |
+| `<C-t>`              | Show todo                 |
+| `<C-_>` / `<C-->`    | Undo                      |
+| `<C-v>`              | Paste                     |
+| `<C-u>`              | Clear line (move to end, then clear to beginning) |
 
 ### Tool-Specific (Codex)
 
-| Key          | Action          |
-| ------------ | --------------- |
-| `<C-t>`      | Show transcript |
-| `<Home>`     | Home            |
-| `<End>`      | End             |
-| `<PageUp>`   | Page up         |
-| `<PageDown>` | Page down       |
-| `q`          | Quit            |
+| Key          | Action                                               |
+| ------------ | ---------------------------------------------------- |
+| `<C-t>`      | Show transcript                                      |
+| `<C-v>`      | Paste                                                |
+| `<C-u>`      | Clear line (move to end, then clear to beginning)    |
+| `<Home>`     | Home                                                 |
+| `<End>`      | End                                                  |
+| `<PageUp>`   | Page up                                              |
+| `<PageDown>` | Page down                                            |
 
 > [!IMPORTANT]
 > Some key combinations (`<C-Enter>`, `<S-Tab>`) require modern terminal emulators like Kitty, WezTerm, or Ghostty. Use alternatives like `<F5>` or `:w` if these don't work.
@@ -468,6 +470,7 @@ vim.keymap.set({ "n", "i" }, "<C-o>", "<Plug>(aibo-send)<C-o>", opts)
 vim.keymap.set({ "n", "i" }, "<C-t>", "<Plug>(aibo-send)<C-t>", opts)
 vim.keymap.set({ "n", "i" }, "<C-_>", "<Plug>(aibo-send)<C-_>", opts)
 vim.keymap.set({ "n", "i" }, "<C-v>", "<Plug>(aibo-send)<C-v>", opts)
+vim.keymap.set({ "n", "i" }, "<C-u>", "<Plug>(aibo-send)<End><Plug>(aibo-send)<C-u>", opts)
 ```
 
 #### Codex Tool

--- a/doc/aibo.txt
+++ b/doc/aibo.txt
@@ -617,14 +617,16 @@ Claude tool mappings:
 	<C-t>		Show todo (n/i)
 	<C-_>		Undo (n/i, also <C-->)
 	<C-v>		Paste (n/i)
+	<C-u>		Clear line - move to end, then clear to beginning (n/i)
 
 Codex tool mappings:
 	<C-t>		Show transcript (n/i)
+	<C-v>		Paste (n/i)
+	<C-u>		Clear line - move to end, then clear to beginning (n/i)
 	<Home>		Move to beginning (n/i)
 	<End>		Move to end (n/i)
 	<PageUp>	Page up (n/i)
 	<PageDown>	Page down (n/i)
-	q		Quit (n)
 
 Note: Some key combinations require modern terminal emulators. Use
 alternatives like <F5> if certain combinations don't work.

--- a/ftplugin/aibo-tool-claude.lua
+++ b/ftplugin/aibo-tool-claude.lua
@@ -18,4 +18,5 @@ if not (cfg and cfg.no_default_mappings) then
   vim.keymap.set({ "n", "i" }, "<C-_>", "<Plug>(aibo-send)<C-_>", opts)
   vim.keymap.set({ "n", "i" }, "<C-->", "<Plug>(aibo-send)<C-_>", opts)
   vim.keymap.set({ "n", "i" }, "<C-v>", "<Plug>(aibo-send)<C-v>", opts)
+  vim.keymap.set({ "n", "i" }, "<C-u>", "<Plug>(aibo-send)<End><Plug>(aibo-send)<C-u>", opts)
 end

--- a/ftplugin/aibo-tool-codex.lua
+++ b/ftplugin/aibo-tool-codex.lua
@@ -11,9 +11,10 @@ local cfg = aibo.get_tool_config("codex")
 if not (cfg and cfg.no_default_mappings) then
   local opts = { buffer = bufnr, nowait = true, silent = true }
   vim.keymap.set({ "n", "i" }, "<C-t>", "<Plug>(aibo-send)<C-t>", opts)
+  vim.keymap.set({ "n", "i" }, "<C-v>", "<Plug>(aibo-send)<C-v>", opts)
+  vim.keymap.set({ "n", "i" }, "<C-u>", "<Plug>(aibo-send)<End><Plug>(aibo-send)<C-u>", opts)
   vim.keymap.set({ "n", "i" }, "<Home>", "<Plug>(aibo-send)<Home>", opts)
   vim.keymap.set({ "n", "i" }, "<End>", "<Plug>(aibo-send)<End>", opts)
   vim.keymap.set({ "n", "i" }, "<PageUp>", "<Plug>(aibo-send)<PageUp>", opts)
   vim.keymap.set({ "n", "i" }, "<PageDown>", "<Plug>(aibo-send)<PageDown>", opts)
-  vim.keymap.set({ "n" }, "q", "<Plug>(aibo-send)q", opts)
 end


### PR DESCRIPTION
## Summary

- Add `<C-u>` (clear line) mapping for Claude and Codex tools
- Add `<C-v>` (paste) mapping for Codex tool
- Remove unused `q` (quit) mapping from Codex tool
- Update documentation in README.md and doc/aibo.txt

## Changes

### Claude tool (`ftplugin/aibo-tool-claude.lua`)
- **Added:** `<C-u>` → Clear line (clear input prompt)

### Codex tool (`ftplugin/aibo-tool-codex.lua`)
- **Added:** `<C-v>` → Paste
- **Added:** `<C-u>` → Clear line (clear input prompt)
- **Removed:** `q` → Quit

### Documentation
- Updated key mapping tables in README.md
- Updated key mapping tables in doc/aibo.txt
- Updated implementation examples in README.md

## Test plan

- [ ] Verify `<C-u>` clears current line in Claude tool
- [ ] Verify `<C-v>` pastes in Codex tool
- [ ] Verify `<C-u>` clears current line in Codex tool
- [ ] Verify documentation matches implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C-u shortcut to clear the current line (moves to line end then clears) in both Claude and Codex tools.
  * Added C-v (paste) shortcut in the Codex tool.

* **Documentation**
  * Updated README and in-app help to show the new key bindings and revised table layout.

* **Changes**
  * Removed the Quit (q) key binding from Codex tool mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->