### PR TITLE
feat: Auto-follow console output when prompt window opens

### DIFF
--- a/lua/aibo/internal/prompt_window.lua
+++ b/lua/aibo/internal/prompt_window.lua
@@ -300,6 +300,13 @@ function M.open(console_winid, options)
     end, 0)
   end
 
+  -- Auto-follow console output when prompt window opens
+  vim.defer_fn(function()
+    if console_info and vim.api.nvim_buf_is_valid(console_info.bufnr) then
+      console.follow(console_info.bufnr)
+    end
+  end, 0)
+
   return {
     winid = winid,
     bufnr = bufnr,


### PR DESCRIPTION
## Summary
- Automatically enables console output following when the prompt window is opened
- Improves UX by keeping the latest console output visible without manual intervention

## Implementation Details
- Added `vim.defer_fn` call to invoke `console.follow()` after prompt window initialization
- Includes buffer validity check to prevent errors if the console buffer is deleted
- Uses the same deferred execution pattern as existing focus management code

## Test Plan
- [ ] Open prompt window and verify console output automatically scrolls to latest
- [ ] Verify no errors occur when console buffer doesn't exist
- [ ] Test interaction with existing focus behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prompt window now automatically follows console output when opened, ensuring you stay synchronized with the latest console activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->