### PR TITLE
Restrict key mappings to appropriate editor modes

### DIFF
--- a/ftplugin/aibo-tool-claude.lua
+++ b/ftplugin/aibo-tool-claude.lua
@@ -32,13 +32,13 @@ if not (cfg and cfg.no_default_mappings) then
     end, { buffer = bufnr, expr = true, silent = true })
   end
   local opts = { buffer = bufnr, nowait = true, silent = true }
-  vim.keymap.set({ "n", "i" }, "<Tab>", "<Plug>(aibo-send)<Tab>", opts)
-  vim.keymap.set({ "n", "i" }, "<S-Tab>", "<Plug>(aibo-send)<S-Tab>", opts)
+  vim.keymap.set({ "n" }, "<Tab>", "<Plug>(aibo-send)<Tab>", opts)
+  vim.keymap.set({ "n" }, "<S-Tab>", "<Plug>(aibo-send)<S-Tab>", opts)
   vim.keymap.set({ "n", "i" }, "<F2>", "<Plug>(aibo-send)<F2>", opts)
-  vim.keymap.set({ "n", "i" }, "<C-o>", "<Plug>(aibo-send)<C-o>", opts)
-  vim.keymap.set({ "n", "i" }, "<C-t>", "<Plug>(aibo-send)<C-t>", opts)
-  vim.keymap.set({ "n", "i" }, "<C-_>", "<Plug>(aibo-send)<C-_>", opts)
-  vim.keymap.set({ "n", "i" }, "<C-->", "<Plug>(aibo-send)<C-_>", opts)
-  vim.keymap.set({ "n", "i" }, "<C-v>", "<Plug>(aibo-send)<C-v>", opts)
-  vim.keymap.set({ "n", "i" }, "<C-u>", "<Plug>(aibo-send)<End><Plug>(aibo-send)<C-u>", opts)
+  vim.keymap.set({ "n" }, "<C-o>", "<Plug>(aibo-send)<C-o>", opts)
+  vim.keymap.set({ "n" }, "<C-t>", "<Plug>(aibo-send)<C-t>", opts)
+  vim.keymap.set({ "n" }, "<C-_>", "<Plug>(aibo-send)<C-_>", opts)
+  vim.keymap.set({ "n" }, "<C-->", "<Plug>(aibo-send)<C-_>", opts)
+  vim.keymap.set({ "i" }, "<C-v>", "<Plug>(aibo-send)<C-v>", opts)
+  vim.keymap.set({ "i" }, "<C-u>", "<Plug>(aibo-send)<End><Plug>(aibo-send)<C-u>", opts)
 end

--- a/ftplugin/aibo-tool-codex.lua
+++ b/ftplugin/aibo-tool-codex.lua
@@ -10,9 +10,9 @@ local aibo = require("aibo")
 local cfg = aibo.get_tool_config("codex")
 if not (cfg and cfg.no_default_mappings) then
   local opts = { buffer = bufnr, nowait = true, silent = true }
-  vim.keymap.set({ "n", "i" }, "<C-t>", "<Plug>(aibo-send)<C-t>", opts)
-  vim.keymap.set({ "n", "i" }, "<C-v>", "<Plug>(aibo-send)<C-v>", opts)
-  vim.keymap.set({ "n", "i" }, "<C-u>", "<Plug>(aibo-send)<End><Plug>(aibo-send)<C-u>", opts)
+  vim.keymap.set({ "i" }, "<C-t>", "<Plug>(aibo-send)<C-t>", opts)
+  vim.keymap.set({ "i" }, "<C-v>", "<Plug>(aibo-send)<C-v>", opts)
+  vim.keymap.set({ "i" }, "<C-u>", "<Plug>(aibo-send)<End><Plug>(aibo-send)<C-u>", opts)
   vim.keymap.set({ "n", "i" }, "<Home>", "<Plug>(aibo-send)<Home>", opts)
   vim.keymap.set({ "n", "i" }, "<End>", "<Plug>(aibo-send)<End>", opts)
   vim.keymap.set({ "n", "i" }, "<PageUp>", "<Plug>(aibo-send)<PageUp>", opts)


### PR DESCRIPTION
## Summary
- Tab, S-Tab, C-o, and C-t mappings in claude tool now only active in normal mode
- C-t, C-v, and C-u mappings in codex tool now only active in insert mode
- Prevents unintended key behavior during text input

## Why
Navigation and command keys (Tab, S-Tab, C-o, C-t) should not interfere with 
insert mode text editing. Similarly, text manipulation keys (C-u, C-v) are insert-mode 
operations that shouldn't trigger in normal mode. This change improves UX by respecting 
Vim mode semantics and preventing accidental activation while typing.

## Test Plan
- [ ] Test Tab/S-Tab navigation in normal mode with claude tool
- [ ] Verify Tab/S-Tab don't interfere with insert mode text entry
- [ ] Test C-u/C-v clipboard operations in insert mode with both tools
- [ ] Verify C-o and C-t work correctly in normal mode for claude tool
- [ ] Test codex tool keybindings work as expected in their respective modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Adjusted keyboard shortcut mode applicability for the aibo tool. Tab/Shift-Tab and Ctrl-based shortcuts now operate in specific editor modes rather than multiple modes for improved focus and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->