### PR TITLE
Follow console after prompt submit

### DIFF
--- a/lua/aibo/internal/prompt_window.lua
+++ b/lua/aibo/internal/prompt_window.lua
@@ -440,6 +440,7 @@ function M.submit(bufnr)
     local b = info.console_info.bufnr
     if vim.api.nvim_buf_is_valid(b) then
       console.submit(b, content)
+      console.follow(b)
     end
   end, 0)
 

--- a/tests/internal/test_prompt_window.lua
+++ b/tests/internal/test_prompt_window.lua
@@ -260,6 +260,7 @@ end
 -- Test submit function
 T["submit sends prompt content to console"] = function()
   local prompt = require("aibo.internal.prompt_window")
+  local console = require("aibo.internal.console_window")
 
   -- Create a console buffer with terminal
   local console_bufnr = vim.api.nvim_create_buf(false, true)
@@ -274,9 +275,22 @@ T["submit sends prompt content to console"] = function()
   vim.b[prompt_bufnr].aibo_console_bufnr = console_bufnr
   vim.api.nvim_buf_set_lines(prompt_bufnr, 0, -1, false, { "Test submission" })
 
+  local original_follow = console.follow
+  local followed = nil
+  console.follow = function(bufnr)
+    followed = bufnr
+  end
+
   -- Test that submit doesn't error
   local ok = pcall(prompt.submit, prompt_bufnr)
   eq(ok, true)
+
+  vim.wait(50, function()
+    return followed ~= nil
+  end)
+  eq(followed, console_bufnr)
+
+  console.follow = original_follow
 end
 
 return T


### PR DESCRIPTION
## Background
After submitting from the prompt window, the console view could remain away from the latest output. This made it easy to miss immediate agent responses right after submit.

## What changed
- `prompt_window.submit()` now calls `console.follow()` after `console.submit()`.
- The follow behavior is now tied directly to submit, not to prompt window close events.
- Prompt submit test coverage is extended to verify that follow is invoked for the associated console buffer.

## Behavior
- Before: following depended on prompt close flow, so latest output visibility was not guaranteed after submit.
- After: submitting from prompt always requests console follow, so the console tracks the newest output right away.

## Scope
- `lua/aibo/internal/prompt_window.lua`
- `tests/internal/test_prompt_window.lua`
