### PR TITLE
fix(submit): increase default submit_delay from 100ms to 500ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ This is particularly useful for sending code snippets, error messages, or other 
 
 ```lua
 require('aibo').setup({
-  submit_delay = 100,         -- Delay in milliseconds (default: 100)
+  submit_delay = 500,         -- Delay in milliseconds (default: 500)
   submit_key = '<CR>',        -- Key to send after submit (default: '<CR>')
   prompt_height = 10,         -- Prompt window height (default: 10)
   prompt_blend_insert = 10,   -- Prompt transparency in Insert mode 0-100 (default: 10)

--- a/doc/aibo.txt
+++ b/doc/aibo.txt
@@ -122,7 +122,7 @@ can call |aibo.setup()| in your configuration to customize the plugin.
 The setup function can be called multiple times to update configuration:
 >
 	require('aibo').setup({
-	  submit_delay = 100,    -- Delay before submit in ms (default: 100)
+	  submit_delay = 500,    -- Delay before submit in ms (default: 500)
 	  submit_key = '<CR>',   -- Key to send after submit (default: '<CR>')
 	  prompt_height = 10,    -- Height of prompt window (default: 10)
 	  prompt_blend_insert = 10, -- Prompt transparency in Insert mode (default: 10)
@@ -522,7 +522,7 @@ aibo.setup({config})
 	Each call merges the new options with the existing configuration.
 >
 		require('aibo').setup({
-		  submit_delay = 100,
+		  submit_delay = 500,
 		  prompt_height = 10,
 		})
 <

--- a/lua/aibo/init.lua
+++ b/lua/aibo/init.lua
@@ -9,7 +9,7 @@ local M = {}
 ---@field console? AiboBufferConfig Configuration for console buffers
 ---@field tools? table<string, AiboBufferConfig> Tool-specific configurations
 ---@field submit_key? string Key to submit input (default: "<CR>")
----@field submit_delay? integer Delay before submit in ms (default: 100)
+---@field submit_delay? integer Delay before submit in ms (default: 500)
 ---@field prompt_height? integer Height of prompt window (default: 10)
 ---@field prompt_blend? integer (deprecated) Prompt window transparency, used as fallback for prompt_blend_insert/prompt_blend_normal
 ---@field prompt_blend_insert? integer Prompt window transparency in Insert mode 0-100 (default: 10)
@@ -32,7 +32,7 @@ local DEFAULTS = {
   -- Tool-specific configurations can be added here
   tools = {},
   submit_key = "<CR>",
-  submit_delay = 100,
+  submit_delay = 500,
   prompt_height = 10,
   prompt_blend_insert = 10,
   prompt_blend_normal = 30,

--- a/tests/internal/test_init.lua
+++ b/tests/internal/test_init.lua
@@ -12,7 +12,7 @@ T["setup function"] = function()
   -- Test default setup
   aibo.setup()
   local config = aibo.get_config()
-  eq(config.submit_delay, 100)
+  eq(config.submit_delay, 500)
   eq(config.prompt_height, 10)
 
   -- Test custom setup


### PR DESCRIPTION
## Summary
- Increase the default `submit_delay` configuration from 100ms to 500ms
- Update documentation (README.md, doc/aibo.txt) to reflect the new default
- Update implementation in lua/aibo/init.lua
- Update test expectations to match the new default value

## Why
The previous 100ms delay was too short and could cause timing issues when submitting prompts. A 500ms delay provides better reliability while still maintaining a responsive user experience.

## Test Plan
- [ ] Verify tests pass with the new default value
- [ ] Test prompt submission behavior with the new delay
- [ ] Confirm documentation accurately reflects the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples with revised default values.

* **Chores**
  * Adjusted default submission delay parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->