### PR TITLE
fix(test): stabilize flaky CI tests (prompt_window + AiboSend isolation)

### DIFF
--- a/tests/commands/test_aibo_send.lua
+++ b/tests/commands/test_aibo_send.lua
@@ -18,6 +18,20 @@ local T = helpers.new_set({
     post_case = function()
       -- Restore original inputlist
       vim.fn.inputlist = original_inputlist
+      -- Close leaked windows and wipe aibo buffers so a case never inherits
+      -- another case's console/prompt windows. Otherwise several console
+      -- windows coexist in the tabpage and AiboSend's disambiguation falls back
+      -- to nvim_tabpage_list_wins order, which differs across Neovim versions
+      -- (observed as a v0.10.0-only failure of "AiboSend -input option").
+      local wins = vim.api.nvim_tabpage_list_wins(0)
+      for i = 2, #wins do
+        pcall(vim.api.nvim_win_close, wins[i], true)
+      end
+      for _, b in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_get_name(b):match("^aibo%a*://") then
+          pcall(vim.api.nvim_buf_delete, b, { force = true })
+        end
+      end
     end,
   },
 })

--- a/tests/internal/test_prompt_window.lua
+++ b/tests/internal/test_prompt_window.lua
@@ -126,12 +126,18 @@ T["compute_float_config returns correct geometry for standard console"] = functi
   local config = { prompt_height = 10 }
   local result = prompt._compute_float_config(winid, config)
 
+  -- The editor may clamp the requested window size (e.g. the cmdline steals a
+  -- row in a headless 24-line UI), so assert against the window's actual size
+  -- rather than the requested 80x24 to keep the test environment-independent.
+  local console_width = vim.api.nvim_win_get_width(winid)
+  local console_height = vim.api.nvim_win_get_height(winid)
+
   eq(result.relative, "win")
   eq(result.win, winid)
   eq(result.height, 10)
-  eq(result.width, 78) -- 80 - 2 for border
+  eq(result.width, math.max(1, console_width - 2)) -- mirror compute_float_config's border clamp
   eq(result.col, 0)
-  eq(result.row, 12) -- 24 - 10 - 2
+  eq(result.row + result.height + 2, console_height) -- bottom-anchored with border
 
   vim.api.nvim_win_close(winid, true)
   vim.api.nvim_buf_delete(bufnr, { force = true })
@@ -510,12 +516,27 @@ T["submit sends prompt content to console"] = function()
   local chan = vim.api.nvim_open_term(console_bufnr, {})
   vim.b[console_bufnr].terminal_job_id = chan
 
-  -- Create and setup prompt buffer
-  local console_winid = 1234
+  -- Open a real window for the console so the prompt can resolve its
+  -- console_info from the live window id. A hardcoded id would only resolve
+  -- when some other window happens to own it, making the test flaky.
+  local console_winid = vim.api.nvim_open_win(console_bufnr, false, {
+    relative = "editor",
+    width = 40,
+    height = 10,
+    row = 0,
+    col = 0,
+  })
+
+  -- Create and setup prompt buffer linked to the real console window
   local prompt_bufname = "aiboprompt://" .. console_winid
   local prompt_bufnr = vim.fn.bufadd(prompt_bufname)
-  vim.b[prompt_bufnr].aibo_console_bufnr = console_bufnr
   vim.api.nvim_buf_set_lines(prompt_bufnr, 0, -1, false, { "Test submission" })
+
+  -- Guard: the prompt must actually resolve the console, otherwise submit
+  -- silently returns before reaching console.follow and the test below would
+  -- pass for the wrong reason.
+  local info = prompt.get_info_by_bufnr(prompt_bufnr)
+  eq(info ~= nil and info.console_info ~= nil, true)
 
   local original_follow = console.follow
   local followed = nil
@@ -533,6 +554,9 @@ T["submit sends prompt content to console"] = function()
   eq(followed, console_bufnr)
 
   console.follow = original_follow
+  if vim.api.nvim_win_is_valid(console_winid) then
+    vim.api.nvim_win_close(console_winid, true)
+  end
 end
 
 return T


### PR DESCRIPTION
## Summary
Fix the tests that failed on CI while passing locally. Root causes were environment/version-dependent test fragility, not source regressions — confirmed by reproducing the exact CI matrix (Ubuntu + Neovim v0.10.0 / nightly) locally in Docker.

- **prompt_window geometry**: stop hard-coding `row = 12`, which assumed an unclamped 80x24 window. A headless UI clamps the float to the available rows, so the console is 23 rows tall and `row = 11` is correct. Assert the bottom-anchored invariant against the window's real size instead.
- **prompt_window submit**: stop linking the prompt to a fabricated console window id (`1234`); resolving `console_info` only succeeds when a live window happens to own that id (nondeterministic). Open a real window for the console buffer and use its live id, plus a guard asserting `console_info` resolves.
- **AiboSend isolation**: the AiboSend cases open console/prompt windows but never close them, so by the `-input` case several `aiboconsole` windows coexist in the tabpage. With more than one console, AiboSend disambiguates over `nvim_tabpage_list_wins` order, which differs by Neovim version — on v0.10.0 a leftover console from an earlier case was picked and `-input` focused the wrong window. Close leaked windows and wipe aibo buffers in `post_case` so each case runs against a clean tabpage.

## Why
All three were test bugs. The geometry formula is correct for the clamped console, `submit` correctly refuses an unresolvable console, and AiboSend's multi-console disambiguation is correct for real usage (a user with one console never hits it) — the test just polluted the tabpage with leftovers from earlier cases.

## Verification
Reproduced the v0.10.0 failure deterministically in an Ubuntu + Neovim v0.10.0 Docker container, then confirmed green across the full matrix locally: **v0.10.0 Linux, nightly Linux, macOS (0.13 and v0.10.0)**.
- prompt_window fixes mutation-verified (breaking the row formula fails geometry; a fabricated winid fails the submit guard).
- AiboSend isolation mutation-verified on v0.10.0 Linux: the case still fails when `-input`'s focus switch is removed, so it is not vacuous.
- `luacheck lua/` + `stylua --check` clean.

## Note
This unblocks #53: that PR branched from a commit with the broken tests, so it stays red until this lands on \`main\` and #53 is rebased onto it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test isolation and cleanup to prevent window and buffer state from leaking between test cases, reducing flaky test failures.
  * Improved test reliability by using actual runtime dimensions instead of hardcoded values, making tests more environment-independent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->