### PR TITLE
feat(ftplugin): add Direct mode for continuous key forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,43 @@ require('aibo').setup({
     --   completion = { claude = true },
     -- },
   },
+
+  -- Live "/" completion sources, one key per tool. Each source probes the
+  -- agent's own live command/skill list -- no static table, no disk scan --
+  -- so it needs no manual updates and can't drift out of sync. No prompt is
+  -- ever sent, so it consumes no tokens.
+  completion = {
+    -- Claude does not speak ACP itself; probes `claude` directly. Needs
+    -- nothing beyond a logged-in `claude` already on PATH -- no adapter,
+    -- no Node.js, no npm. On by default: there is no static fallback, so
+    -- setting this to `false` means no "/" completion at all for Claude.
+    claude = true,
+    -- claude = {
+    --   cmd = { "claude" }, -- command to probe, looked up on PATH
+    --   timeout = 10000,    -- probe timeout (ms)
+    -- },
+    -- claude = false,      -- disable "/" completion for Claude entirely
+
+    -- Codex does not speak ACP itself; probes `codex app-server` directly.
+    -- Needs nothing beyond `codex` already on PATH. On by default: there is
+    -- no static fallback, so `false` means no "/" completion for Codex.
+    codex = true,
+    -- codex = {
+    --   cmd = { "codex" },
+    --   timeout = 10000,
+    -- },
+    -- codex = false,       -- disable "/" completion for Codex entirely
+
+    -- Generic Agent Client Protocol (ACP) client, for agents that speak ACP
+    -- natively. Currently used by Gemini CLI (`gemini --acp`). On by
+    -- default: same reasoning as Claude/Codex -- no static fallback.
+    acp = true,
+    -- acp = {
+    --   cmd = { "gemini", "--acp" },
+    --   timeout = 10000,
+    -- },
+    -- acp = false,         -- disable "/" completion for Gemini entirely
+  },
 })
 ```
 
@@ -404,6 +441,8 @@ require('aibo').setup({
 > [!NOTE]
 >
 > `<C-g><C-o>` enters a special mode where you can press any single key to send it to the terminal. Useful for sending arbitrary keys not mapped by default.
+>
+> `<C-g>i` (or `<C-g><C-i>`) enters Direct mode, where every key you press is forwarded to the terminal until you press `<Esc>`. `<Esc>` itself is never forwarded — press `<C-c>` while in Direct mode to send ESC to the tool. While active, a 5-line window with a thick red border appears at the top of the console explaining the mode; the prompt window (if shown) is hidden for the duration and reopened in the same state afterwards.
 
 ### Console Buffer
 
@@ -422,6 +461,7 @@ Most keys use the `<Plug>(aibo-send)<Key>` pattern to send keys directly to the 
 | `<Down>`     | Send down arrow                 | `<Plug>(aibo-send)<Down>` |
 | `<Up>`       | Send up arrow                   | `<Plug>(aibo-send)<Up>`   |
 | `<C-g><C-o>` | Send any single key (n)         | `<Plug>(aibo-send)`       |
+| `<C-g>i` / `<C-g><C-i>` | Enter Direct mode (n) | `<Plug>(aibo-direct)` |
 
 ### Prompt Buffer
 
@@ -434,6 +474,7 @@ Most keys use the `<Plug>(aibo-send)<Key>` pattern to send keys directly to the 
 | `<C-p>`       | Previous history or completion (i) | `<Plug>(aibo-history-prev)`     |
 | `<C-n>`       | Next history or completion (i)     | `<Plug>(aibo-history-next)`     |
 | `<C-g><C-o>`  | Send any single key (n/i)          | `<Plug>(aibo-send)`             |
+| `<C-g>i` / `<C-g><C-i>` | Enter Direct mode (n/i) | `<Plug>(aibo-direct)` |
 
 > [!NOTE]
 > `<C-p>` and `<C-n>` in insert mode intelligently switch between history navigation and completion menu navigation. When the completion popup menu is visible, they navigate the completion menu. When the popup is not visible, they navigate through your prompt history.

--- a/doc/aibo.txt
+++ b/doc/aibo.txt
@@ -624,6 +624,7 @@ Console buffer mappings:
 	<Down>		Send down arrow (n)
 	<Up>		Send up arrow (n)
 	<C-g><C-o>	Send any single key (n)
+	<C-g>i		Enter Direct mode (n, also <C-g><C-i>)
 
 Prompt buffer mappings:
 	<CR>		Submit content (n)
@@ -631,9 +632,18 @@ Prompt buffer mappings:
 	<C-Enter>	Submit and close (n/i)
 	<F5>		Submit and close (n/i)
 	<C-g><C-o>	Send any single key (n/i)
+	<C-g>i		Enter Direct mode (n/i, also <C-g><C-i>)
 
 Note: Press <C-g><C-o> followed by any key to send that key to the terminal.
 This is useful for sending keys not mapped by default.
+
+Note: Press <C-g>i (or <C-g><C-i>) to enter Direct mode, where every key you
+press is forwarded to the terminal until you press <Esc>. <Esc> itself is
+never forwarded to the tool; press <C-c> while in Direct mode if you need to
+send ESC. While active, a 5-line window with a thick red border is shown at
+the top of the console explaining the mode. If the prompt window is
+visible it is hidden for the duration and reopened in the same Normal or
+Insert state once Direct mode ends.
 
 Claude tool mappings:
 	<Tab>		Toggle think (n/i)
@@ -664,10 +674,12 @@ All functionality is exposed through <Plug> mappings defined in ftplugin
 files. These can be used to create custom key mappings.
 
 Core <Plug> mappings~
-			*<Plug>(aibo-send)* *<Plug>(aibo-submit)*
+			*<Plug>(aibo-send)* *<Plug>(aibo-direct)* *<Plug>(aibo-submit)*
 			*<Plug>(aibo-jump)* *<Plug>(aibo-jump-or-submit)*
 
 	<Plug>(aibo-send)	Prefix for sending keys to terminal
+	<Plug>(aibo-direct)	Enter Direct mode: forward every key to the
+				terminal until <Esc> is pressed
 	<Plug>(aibo-submit)	Submit content to terminal
 	<Plug>(aibo-jump)	Alias for <Plug>(aibo-jump:tabdrop).
 				Remap this to change the default opener.
@@ -693,6 +705,15 @@ The `<Plug>(aibo-send)` mapping is designed to be used in two ways:
 
 It automatically converts Vim key notation to terminal escape sequences
 and sends them to the underlying process.
+
+The `<Plug>(aibo-direct)` mapping (mapped to <C-g>i / <C-g><C-i> by default)
+repeats the same single-key capture used by `<Plug>(aibo-send)`, forwarding
+each captured key until <Esc> is pressed. <Esc> is never forwarded to the
+tool; use <C-c> from within Direct mode to send ESC instead. While active, a
+fixed 5-line window with a thick red border and the title "Direct mode" is
+shown at the top of the console, explaining the mode and how to exit it.
+If the prompt window is visible, it is hidden for the duration and reopened
+in the same Normal or Insert state once Direct mode ends.
 
 Common usage patterns:
 	<Plug>(aibo-send)<Esc>		Send ESC to terminal

--- a/ftplugin/aibo-console.lua
+++ b/ftplugin/aibo-console.lua
@@ -20,6 +20,8 @@ local cfg = aibo.get_buffer_config("console")
 if not (cfg and cfg.no_default_mappings) then
   local opts = { buffer = bufnr, nowait = true, silent = true }
   vim.keymap.set("n", "<C-g><C-o>", "<Plug>(aibo-send)", { buffer = bufnr, nowait = true })
+  vim.keymap.set("n", "<C-g>i", "<Plug>(aibo-direct)", { buffer = bufnr, nowait = true })
+  vim.keymap.set("n", "<C-g><C-i>", "<Plug>(aibo-direct)", { buffer = bufnr, nowait = true })
   vim.keymap.set("n", "<CR>", "<Plug>(aibo-jump-or-submit)", opts)
   vim.keymap.set("n", "<C-Enter>", "<Plug>(aibo-submit)", opts)
   vim.keymap.set("n", "<F5>", "<Plug>(aibo-submit)", opts)

--- a/ftplugin/aibo-prompt.lua
+++ b/ftplugin/aibo-prompt.lua
@@ -17,6 +17,8 @@ local cfg = aibo.get_buffer_config("prompt")
 if not (cfg and cfg.no_default_mappings) then
   local opts = { buffer = bufnr, nowait = true, silent = true }
   vim.keymap.set({ "n", "i" }, "<C-g><C-o>", "<Plug>(aibo-send)", { buffer = bufnr, nowait = true })
+  vim.keymap.set({ "n", "i" }, "<C-g>i", "<Plug>(aibo-direct)", { buffer = bufnr, nowait = true })
+  vim.keymap.set({ "n", "i" }, "<C-g><C-i>", "<Plug>(aibo-direct)", { buffer = bufnr, nowait = true })
   vim.keymap.set("n", "<CR>", "<Plug>(aibo-submit)", opts)
   vim.keymap.set("n", "<Esc>", "<Cmd>q<CR>", opts)
   vim.keymap.set("n", "<C-Enter>", "<Plug>(aibo-submit)<Cmd>q<CR>", opts)

--- a/lua/aibo/internal/console_window.lua
+++ b/lua/aibo/internal/console_window.lua
@@ -169,6 +169,21 @@ local function setup_mappings(bufnr)
       send(key)
     end
   end)
+  define("<Plug>(aibo-direct)", "Enter Direct mode: forward every key to the tool until <Esc>", function()
+    local winid = vim.api.nvim_get_current_win()
+    local info = M.get_info_by_winid(winid)
+    if not info then
+      return
+    end
+    -- Resolve the target bufnr up front rather than inside send_fn: Direct
+    -- mode may close other windows (e.g. hides a visible prompt) while
+    -- looping, so relying on "current window" per keystroke is unreliable.
+    local direct_mode = require("aibo.internal.direct_mode")
+    direct_mode.enter(winid, function(key)
+      local code = aibo.resolve(key) or key
+      M.send(info.bufnr, code)
+    end)
+  end)
   define("<Plug>(aibo-submit)", "Submit to the tool", function()
     submit("")
   end)

--- a/lua/aibo/internal/direct_mode.lua
+++ b/lua/aibo/internal/direct_mode.lua
@@ -1,0 +1,135 @@
+--- Direct mode: continuously forward key presses to a console's tool.
+---
+--- Unlike the one-shot `<Plug>(aibo-send)` capture (which sends a single key
+--- and returns immediately), Direct mode repeats the capture until <Esc> is
+--- pressed. <Esc> itself is never forwarded -- it always exits Direct mode,
+--- consistent with the rest of Aibo where the physical <Esc> key is reserved
+--- for Vim and never sent to the tool as a raw byte.
+---
+--- While active, a fixed 5-line floating window is shown at the top of the
+--- console explaining the mode and how to exit it. If a prompt window is
+--- currently visible for the console, it is hidden for the duration and
+--- reopened (in the same Normal/Insert state) once Direct mode ends.
+local M = {}
+
+local TITLE = " Direct mode "
+local HEIGHT = 5
+local CONTENT = {
+  "Direct mode forwards every key you press",
+  "directly to the tool.",
+  "",
+  "  <Esc>   Exit Direct mode",
+  "  <C-c>   Send ESC to the tool",
+}
+
+-- Thick border, as opposed to the thin "rounded" border used elsewhere.
+local BORDER = { "┏", "━", "┓", "┃", "┛", "━", "┗", "┃" }
+
+--- Registry of indicator windows currently shown, keyed by console winid.
+--- Exposed for testing only.
+local active_indicators = {}
+
+---@param console_winid number
+---@return number indicator winid
+local function open_indicator(console_winid)
+  local prompt = require("aibo.internal.prompt_window")
+  prompt.ensure_highlights()
+
+  local width = vim.api.nvim_win_get_width(console_winid)
+
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.bo[bufnr].bufhidden = "wipe"
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, CONTENT)
+  vim.bo[bufnr].modifiable = false
+
+  local winid = vim.api.nvim_open_win(bufnr, false, {
+    relative = "win",
+    win = console_winid,
+    row = 0,
+    col = 0,
+    width = math.max(1, width - 2),
+    height = HEIGHT,
+    style = "minimal",
+    border = BORDER,
+    title = TITLE,
+    title_pos = "left",
+    focusable = false,
+    zindex = 200,
+  })
+  vim.wo[winid].winhighlight = "FloatBorder:AiboDirectBorder,FloatTitle:AiboDirectTitle"
+  return winid
+end
+
+---@param winid number?
+local function close_indicator(winid)
+  if winid and vim.api.nvim_win_is_valid(winid) then
+    pcall(vim.api.nvim_win_close, winid, true)
+  end
+end
+
+--- Hide a console's visible prompt window for the duration of Direct mode.
+---@param console_winid number
+---@return boolean had_prompt True if a prompt window was visible and hidden
+---@return boolean was_insert True if the prompt itself was focused in Insert mode
+local function hide_prompt(console_winid)
+  local prompt = require("aibo.internal.prompt_window")
+  local info = prompt.get_info_by_console_winid(console_winid)
+  if not info or not vim.api.nvim_win_is_valid(info.winid) then
+    return false, false
+  end
+  local was_insert = vim.api.nvim_get_current_win() == info.winid and vim.fn.mode():match("^[iR]") ~= nil
+  pcall(vim.api.nvim_win_close, info.winid, true)
+  return true, was_insert
+end
+
+---@param console_winid number
+---@param was_insert boolean
+local function restore_prompt(console_winid, was_insert)
+  local prompt = require("aibo.internal.prompt_window")
+  prompt.open(console_winid, { startinsert = was_insert })
+end
+
+--- Enter Direct mode for a console window.
+--- Repeatedly captures a single key and passes it to `send_fn`, until <Esc>
+--- is pressed or key capture is interrupted. <Esc> is never forwarded.
+---
+--- @param console_winid number The console window ID to show the indicator on
+--- @param send_fn fun(key: string) Called with each captured key (Vim key notation)
+function M.enter(console_winid, send_fn)
+  local keycode = require("aibo.internal.keycode")
+
+  local had_prompt, was_insert = hide_prompt(console_winid)
+  local indicator_winid = open_indicator(console_winid)
+  active_indicators[console_winid] = indicator_winid
+  -- Paint the indicator before the first (blocking) getchar() call.
+  vim.cmd("redraw")
+
+  local ok, err = pcall(function()
+    while true do
+      local key = keycode.get_single_keycode()
+      if not key or key == "<Esc>" then
+        break
+      end
+      send_fn(key)
+      -- The tool's terminal echo of what was just sent arrives
+      -- asynchronously; give it a moment to land, then repaint, otherwise
+      -- it visibly lags by one keystroke behind what was actually typed.
+      vim.wait(50)
+      vim.cmd("redraw!")
+    end
+  end)
+
+  close_indicator(indicator_winid)
+  active_indicators[console_winid] = nil
+  if had_prompt then
+    restore_prompt(console_winid, was_insert)
+  end
+  if not ok then
+    error(err, 0)
+  end
+end
+
+-- Exposed for testing only
+M._active_indicators = active_indicators
+
+return M

--- a/lua/aibo/internal/prompt_window.lua
+++ b/lua/aibo/internal/prompt_window.lua
@@ -89,6 +89,9 @@ local function setup_highlights()
   vim.api.nvim_set_hl(0, "AiboPromptTitle", { default = true, link = "DiagnosticInfo" })
   vim.api.nvim_set_hl(0, "AiboPromptInsertBorder", { default = true, link = "DiagnosticWarn" })
   vim.api.nvim_set_hl(0, "AiboPromptInsertTitle", { default = true, link = "DiagnosticWarn" })
+  -- Shared with aibo.internal.direct_mode's console overlay window.
+  vim.api.nvim_set_hl(0, "AiboDirectBorder", { default = true, link = "DiagnosticError" })
+  vim.api.nvim_set_hl(0, "AiboDirectTitle", { default = true, link = "DiagnosticError" })
 end
 
 --- Ensure prompt highlight groups are defined (once per session).
@@ -105,6 +108,10 @@ local function ensure_highlights()
     callback = setup_highlights,
   })
 end
+
+-- Exposed so aibo.internal.direct_mode can ensure the shared highlight
+-- groups exist before styling its own overlay window.
+M.ensure_highlights = ensure_highlights
 
 --- Apply mode-specific highlights and winblend to prompt window.
 --- In Insert mode, uses AiboPromptInsertBorder/Title and lower winblend (more opaque).
@@ -207,6 +214,23 @@ local function setup_mappings(bufnr)
     if key then
       send(key)
     end
+  end)
+  define("<Plug>(aibo-direct)", "Enter Direct mode: forward every key to associated console until <Esc>", function()
+    local winid = vim.api.nvim_get_current_win()
+    local info = M.get_info_by_winid(winid)
+    if not info or not info.console_info then
+      return
+    end
+    -- Resolve the target bufnr up front rather than inside send_fn: entering
+    -- Direct mode from the prompt closes the prompt window itself (to show
+    -- the indicator instead), so send_fn can no longer rely on "current
+    -- window" being the prompt by the time it's called from the loop.
+    local console_bufnr = info.console_info.bufnr
+    local direct_mode = require("aibo.internal.direct_mode")
+    direct_mode.enter(info.console_info.winid, function(key)
+      local code = aibo.resolve(key) or key
+      console.send(console_bufnr, code)
+    end)
   end)
   define("<Plug>(aibo-submit)", "Submit prompt to associated console", function()
     vim.cmd("write")

--- a/tests/internal/test_direct_mode.lua
+++ b/tests/internal/test_direct_mode.lua
@@ -1,0 +1,160 @@
+local eq = MiniTest.expect.equality
+local helpers = require("tests.helpers")
+
+local T = helpers.new_set()
+
+T["enter forwards captured keys to send_fn and exits on <Esc> without forwarding it"] = function()
+  local direct_mode = require("aibo.internal.direct_mode")
+
+  local console_bufnr = vim.api.nvim_create_buf(false, true)
+  local console_winid = vim.api.nvim_open_win(console_bufnr, true, {
+    relative = "editor",
+    width = 80,
+    height = 24,
+    row = 0,
+    col = 0,
+  })
+
+  local calls = 0
+  local indicator_seen_open = false
+  local indicator_title = nil
+  local original_getchar = vim.fn.getchar
+  vim.fn.getchar = function()
+    calls = calls + 1
+    if calls == 1 then
+      local indicator_winid = direct_mode._active_indicators[console_winid]
+      indicator_seen_open = indicator_winid ~= nil and vim.api.nvim_win_is_valid(indicator_winid)
+      if indicator_seen_open then
+        indicator_title = vim.api.nvim_win_get_config(indicator_winid).title[1][1]
+      end
+      return string.byte("a")
+    end
+    return 27 -- <Esc>
+  end
+
+  local sent = {}
+  direct_mode.enter(console_winid, function(key)
+    table.insert(sent, key)
+  end)
+
+  vim.fn.getchar = original_getchar
+
+  eq(indicator_seen_open, true)
+  eq(indicator_title, " Direct mode ")
+  eq(sent, { "a" })
+  eq(direct_mode._active_indicators[console_winid], nil)
+
+  vim.api.nvim_win_close(console_winid, true)
+end
+
+T["enter exits immediately when the first key is <Esc>"] = function()
+  local direct_mode = require("aibo.internal.direct_mode")
+
+  local console_bufnr = vim.api.nvim_create_buf(false, true)
+  local console_winid = vim.api.nvim_open_win(console_bufnr, true, {
+    relative = "editor",
+    width = 80,
+    height = 24,
+    row = 0,
+    col = 0,
+  })
+
+  local original_getchar = vim.fn.getchar
+  vim.fn.getchar = function()
+    return 27 -- <Esc>
+  end
+
+  local sent = {}
+  direct_mode.enter(console_winid, function(key)
+    table.insert(sent, key)
+  end)
+
+  vim.fn.getchar = original_getchar
+
+  eq(sent, {})
+  eq(direct_mode._active_indicators[console_winid], nil)
+
+  vim.api.nvim_win_close(console_winid, true)
+end
+
+T["enter hides a visible prompt window and reopens it after exiting"] = function()
+  local direct_mode = require("aibo.internal.direct_mode")
+  local prompt = require("aibo.internal.prompt_window")
+  local console = require("aibo.internal.console_window")
+
+  local console_bufnr = vim.api.nvim_create_buf(false, true)
+  local console_winid = vim.api.nvim_open_win(console_bufnr, true, {
+    relative = "editor",
+    width = 80,
+    height = 24,
+    row = 0,
+    col = 0,
+  })
+
+  local original_get_info = console.get_info_by_winid
+  console.get_info_by_winid = function(winid)
+    return {
+      winid = winid,
+      bufnr = console_bufnr,
+      bufname = "aiboconsole://test//",
+      jobinfo = { cmd = "test", args = {}, job_id = 42 },
+    }
+  end
+
+  local prompt_info = prompt.open(console_winid, { startinsert = false })
+  local prompt_bufnr = prompt_info.bufnr
+
+  local prompt_winid_during_direct = nil
+  local original_getchar = vim.fn.getchar
+  vim.fn.getchar = function()
+    prompt_winid_during_direct = prompt.get_info_by_console_winid(console_winid)
+    return 27 -- <Esc>
+  end
+
+  direct_mode.enter(console_winid, function() end)
+
+  vim.fn.getchar = original_getchar
+
+  -- The prompt window was closed for the duration of Direct mode; the buffer
+  -- itself survives (bufhidden=hide) but no window shows it (winid == -1).
+  eq(prompt_winid_during_direct ~= nil, true)
+  eq(prompt_winid_during_direct.winid, -1)
+
+  -- ...and reopened (same buffer) once Direct mode exited.
+  local reopened = prompt.get_info_by_console_winid(console_winid)
+  eq(reopened ~= nil, true)
+  eq(reopened.bufnr, prompt_bufnr)
+  eq(vim.api.nvim_win_is_valid(reopened.winid), true)
+
+  console.get_info_by_winid = original_get_info
+  vim.api.nvim_win_close(console_winid, true)
+end
+
+T["enter does nothing prompt-related when no prompt window is visible"] = function()
+  local direct_mode = require("aibo.internal.direct_mode")
+  local prompt = require("aibo.internal.prompt_window")
+
+  local console_bufnr = vim.api.nvim_create_buf(false, true)
+  local console_winid = vim.api.nvim_open_win(console_bufnr, true, {
+    relative = "editor",
+    width = 80,
+    height = 24,
+    row = 0,
+    col = 0,
+  })
+
+  local original_getchar = vim.fn.getchar
+  vim.fn.getchar = function()
+    return 27 -- <Esc>
+  end
+
+  direct_mode.enter(console_winid, function() end)
+
+  vim.fn.getchar = original_getchar
+
+  eq(prompt.get_info_by_console_winid(console_winid), nil)
+
+  vim.api.nvim_win_close(console_winid, true)
+end
+
+return T


### PR DESCRIPTION
## Summary
- Add Direct mode: `<C-g>i` (or `<C-g><C-i>`) repeats the existing single-key capture (`<C-g><C-o>`) until `<Esc>` is pressed, forwarding every key to the tool in between instead of one at a time.
- `<Esc>` is never forwarded to the tool while in Direct mode, consistent with the rest of Aibo's keymaps (send ESC via `<C-c>` instead).
- While active, a fixed 5-line window with a thick red border and the title "Direct mode" is shown at the top of the console, explaining the mode and how to exit it.
- If the prompt window is visible, it is hidden for the duration and reopened in the same Normal/Insert state once Direct mode ends.
- Also links the new per-tool vimdoc help pages (`aibo-live-completion.txt`, `aibo-acp.txt`, `aibo-claude.txt`, `aibo-codex.txt`) from the README.

## Why
Oneshot capture (`<C-g><C-o>`) sends exactly one key per invocation, which gets tedious for back-to-back interactions like navigating a tool's interactive menu (arrow-key navigation, repeated confirmations, etc.). Direct mode removes the need to re-invoke the prefix for every single keystroke while keeping the same underlying key-resolution/forwarding mechanism, and keeps the "Esc is always Vim's, never the tool's" invariant intact.

## Test Plan
- [x] `just check` (luacheck + stylua + full test suite, 292 cases) passes
- [x] Manually verified in a real Neovim session (via tmux): entering Direct mode from both the console and prompt buffers, the red-bordered indicator window appearing/disappearing correctly, prompt hide/restore (including Insert-mode restoration), key forwarding reaching the underlying tool without lag, and `<Esc>` exiting without being forwarded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Direct mode** for interactive input, letting you send keys straight to the terminal until you exit with `<Esc>`.
  * Introduced a visible Direct mode indicator and updated default key mappings to launch it with `<C-g>i` / `<C-g><C-i>`.

* **Documentation**
  * Clarified completion behavior for supported tools and updated key mapping docs to cover Direct mode and related `<Plug>` actions.

* **Tests**
  * Added coverage for Direct mode behavior, including key forwarding and prompt window hide/restore handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->